### PR TITLE
Fix deprecation on aws_iam_policy_document.source_json in favor of source_policy_documents attr.

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 **/.idea
 **/*.iml
 
+.vscode
+
 # Cloud Posse Build Harness https://github.com/cloudposse/build-harness
 **/.build-harness
 **/build-harness

--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,8 @@ data "aws_iam_policy_document" "resource_full_access" {
 }
 
 data "aws_iam_policy_document" "resource" {
-  count       = module.this.enabled ? 1 : 0
-  source_json = local.principals_full_access_non_empty ? join("", [data.aws_iam_policy_document.resource_full_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
+  count                   = module.this.enabled ? 1 : 0
+  source_policy_documents = local.principals_full_access_non_empty ? [data.aws_iam_policy_document.resource_full_access[0].json] : [data.aws_iam_policy_document.empty[0].json]
 }
 
 resource "aws_ecrpublic_repository_policy" "this" {


### PR DESCRIPTION


## what
* I was getting deprecation warning for `data.aws_iam_policy_document.resource.source_json` attribute:
  ```bash
  │ Warning: Argument is deprecated
  │
  │   with module.ecr_public.module.ecr_public.data.aws_iam_policy_document.resource,
  │   on .terraform-devops/modules/ecr_public.ecr_public/main.tf line 43, in data "aws_iam_policy_document" "resource":
  │   43:   source_json = local.principals_full_access_non_empty ? join("", [data.aws_iam_policy_document.resource_full_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
  │
  │ Use the attribute "source_policy_documents" instead.
  │
  │ (and one more similar warning elsewhere)
  ```

## why
* Simple fix for deprecated attribute, [please see docs here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#source_json)!

## references
* [Documentation on source_json being deprecated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#source_json) 


